### PR TITLE
Fixes issue where plugin could not be activated if settings did not exist

### DIFF
--- a/embed-sendy.php
+++ b/embed-sendy.php
@@ -54,7 +54,9 @@ final class Embed_Sendy {
 				'apiKey'   => self::get_option( 'esd_sendy_api' ),
 			);
 
-			if ( in_array( null, $config, true ) || in_array( '', $config, true ) ) {
+			try {
+				self::$sendy_api = new \SENDY\API( $config );
+			} catch ( Exception $e ) {
 				add_action(
 					'admin_notices',
 					function() {
@@ -75,8 +77,6 @@ final class Embed_Sendy {
 				);
 				return;
 			}
-
-			self::$sendy_api = new \SENDY\API( $config );
 
 			add_shortcode( 'embed_sendy', array( self::$instance, 'embed_sendy_shortcode' ) );
 			add_action( 'wp_enqueue_scripts', array( self::$instance, 'frontend_scripts' ) );


### PR DESCRIPTION
When I installed the plugin on my personal site, I got the following exception:

> Fatal error: Uncaught Exception: Required config parameters [sendyUrl, listId, apiKey] is not set or empty in /srv/users/userfa364bbd/apps/userfa364bbd/public/wp-content/plugins/embed-sendy/includes/class-api.php:88 Stack trace: #0 /srv/users/userfa364bbd/apps/userfa364bbd/public/wp-content/plugins/embed-sendy/embed-sendy.php(79): SENDY\API->__construct(Array) #1 /srv/users/userfa364bbd/apps/userfa364bbd/public/wp-content/plugins/embed-sendy/embed-sendy.php(565): Embed_Sendy::instance() #2 /srv/users/userfa364bbd/apps/userfa364bbd/public/wp-content/plugins/embed-sendy/embed-sendy.php(568): ESD() #3 /srv/users/userfa364bbd/apps/userfa364bbd/public/wp-admin/includes/plugin.php(2255): include('/srv/users/user...') #4 /srv/users/userfa364bbd/apps/userfa364bbd/public/wp-admin/plugins.php(177): plugin_sandbox_scrape('embed-sendy/emb...') #5 {main} thrown in /srv/users/userfa364bbd/apps/userfa364bbd/public/wp-content/plugins/embed-sendy/includes/class-api.php on line 88

After looking at the code, that exception is thrown in the `includes/class-api.php` file when the expected argumnets are not supplied to the constructor, which makes sense. It appears that the exception logic was added in version 1.2, when the plugin moved away from displaying an admin notice.

In the Embed_Sendy class, there is some logic to check that the `$config` array, the arguments that get sent to the Sendy API constructor are set, but unfortunately, that logic doesn't check if any of the values are false, which is necessary since `Embed_Sendy::get_option()` will return false by default.

Since the Sendy API class already handles validating the arguments it receives, this PR decides to lean into that and remove the duplicated logic in the Embed_Sendy class. Instead, the Embed_Sendy class will simply try to catch the Exception that is thrown by the Sendy API constructor.

**Testing instructions**

- Create a fresh site
- Installed `embed-sendy`
- Activated `embed-sendy`
- Notice plugin is not activated due to error
- Checkout this branch
- Activated `embed-sendy`
- Notice that `embed-sendy` is activated and that you receive notice that the settings are not set