### PR TITLE
Correct @reteurn in Embed_Sendy::get_option() docblock

### DIFF
--- a/embed-sendy.php
+++ b/embed-sendy.php
@@ -212,7 +212,7 @@ final class Embed_Sendy {
 	 *
 	 * @param string $key Settings ID.
 	 * @param string $section Section ID.
-	 * @return array
+	 * @return mixed Returns value if found or false.
 	 */
 	public static function get_option( $key, $section = 'esd_settings' ) {
 		$settings = get_option( $section );


### PR DESCRIPTION
The `@return` section in the `Embed_Sendy::get_option()` docblock is incorrect. That method does not return only an array since the default value is `false`.